### PR TITLE
Defensive handling for env variables

### DIFF
--- a/src/commands/react.js
+++ b/src/commands/react.js
@@ -18,8 +18,8 @@ export function startReactServer(buildConfig = {}) {
         clientStats
       })
     ],
-    enableCSP: process.env.ENABLE_CSP !== "false",
-    enableNonce: process.env.ENABLE_NONCE !== "false"
+    enableCSP: process.env.ENABLE_CSP === "true",
+    enableNonce: process.env.ENABLE_NONCE === "true"
   })
 
   server.listen(process.env.SERVER_PORT, () => {


### PR DESCRIPTION
Only enable options if the env variables are set to "true". Missing env variables should not enable those options.