### PR TITLE
Add hook to change webpack config

### DIFF
--- a/src/builder.js
+++ b/src/builder.js
@@ -447,5 +447,10 @@ export default function builder(target, env = "development", config = {}) {
       //   verbose: true
       // }) : null
     ].filter(Boolean)
+  }, {
+    isServer,
+    isClient,
+    isProduction,
+    isDevelopment
   })
 }

--- a/src/builder.js
+++ b/src/builder.js
@@ -97,6 +97,8 @@ const babelFiles = /\.(js|mjs|jsx)$/
 const postcssFiles = /\.(css|sss|pcss)$/
 const compressableAssets = /\.(ttf|otf|svg|pdf|html|ico|txt|md|html|js|css|json|xml)$/
 
+const identityFnt = (item) => item
+
 export default function builder(target, env = "development", config = {}) {
   const SERVER_OUTPUT = config.output.server
   const CLIENT_OUTPUT = config.output.client
@@ -192,7 +194,9 @@ export default function builder(target, env = "development", config = {}) {
   const HAS_VENDOR = fs.existsSync(VENDOR_ENTRY)
   const HAS_MAIN = fs.existsSync(MAIN_ENTRY)
 
-  return {
+  const WEBPACK_HOOK = config.hook.webpack ? config.hook.webpack : identityFnt
+
+  return WEBPACK_HOOK({
     name,
     target: webpackTarget,
     devtool,
@@ -444,5 +448,5 @@ export default function builder(target, env = "development", config = {}) {
       //   verbose: true
       // }) : null
     ].filter(Boolean)
-  }
+  })
 }

--- a/src/defaultConfig.js
+++ b/src/defaultConfig.js
@@ -23,5 +23,7 @@ export default {
     server: "build/server",
     client: "build/client",
     public: "/static/"
-  }
+  },
+
+  hook: {}
 }


### PR DESCRIPTION
# Summary
This PR adds general hooks functionality to edge-builder. The currently only implemented hook is a webpack config hook.
The purpose of this is to change webpack config after edge-builder created its default webpack config. So the developer can add modules, loaders etc.
My use case is adding markdown loader to webpack so I can do an `import content from "./content.md"`

**The default behaviour does not change so this is a non breaking change**

# How to use
Add a configuration entry `hook.webpack` to your projects **edgerc.yml** file. It should point to a node javascript module relative to the projects root. This module should export one function that gets the current webpack config as first parameter and returns the new webpack config.